### PR TITLE
Cache accessible paths only

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -355,17 +355,18 @@ ${error.stack}`);
   // COMMON //
   ////////////
 
-  private pathExistenceCache = new Map<string, boolean>();
+  private pathExistenceCache = new Set<string>();
 
   private fsExistsSync(path: string): boolean {
     if (this.production) {
-      if (this.pathExistenceCache.has(path)) {
-        return this.pathExistenceCache.get(path)!;
-      } else {
-        let exists = FS.existsSync(path);
-        this.pathExistenceCache.set(path, exists);
-        return exists;
+      let exists = this.pathExistenceCache.has(path);
+      if (!exists) {
+        exists = FS.existsSync(path);
+        if (exists) {
+          this.pathExistenceCache.add(path);
+        }
       }
+      return exists;
     } else {
       return FS.existsSync(path);
     }


### PR DESCRIPTION
The current behavior of `fsExistsSync` function is always cache for unknown paths. If an attacker or web crawler issue a lot of random invalid access, the process memory will bloat.